### PR TITLE
TRT-315: Include commit history in release notes.

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -42,9 +42,9 @@ jobs:
 
     steps:
       - name: Checkout Harmony-SMAP-L2-gridding-service repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
-          lfs: true
+          fetch-depth: 0
 
       - name: Extract semantic version number
         run: echo "semantic_version=$(cat docker/service_version.txt)" >> $GITHUB_ENV

--- a/.github/workflows/run_lib_tests.yml
+++ b/.github/workflows/run_lib_tests.yml
@@ -14,9 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Harmony-SMAP-L2-gridding-service repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/run_service_tests.yml
+++ b/.github/workflows/run_service_tests.yml
@@ -18,9 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Harmony-SMAP-L2-gridding-service repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
+        uses: actions/checkout@v5
 
       - name: Build service image
         run: ./bin/build-image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [vX.Y.Z] - Unreleased
+
+### Changed
+
+- Release notes for the SMAP L2 Gridding service will now include the commit
+  history for that release.
+
 ## [v1.0.0] - 2025-07-29
 
 ### Changed

--- a/bin/extract-release-notes.sh
+++ b/bin/extract-release-notes.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 ##################################################################################
 #
-# Extract release notes for the latest version of Harmony SMAP L2 gridding service
+# 2024-12-04: Extract release notes for the latest version of Harmony SMAP L2 gridding service
+# 2025-09-23: Append git commit messages to release notes.
 #
 ##################################################################################
 
@@ -13,13 +14,34 @@ CHANGELOG_FILE="CHANGELOG.md"
 VERSION_PATTERN="^## [\[]v"
 
 ## captures url links
-## [unreleased]:https://github.com/nasa/harmony-browse-image-generator/compare/1.2.0..HEAD
-## [v1.2.0]: https://github.com/nasa/harmony-browse-image-generator/compare/1.1.0..1.2.0
-LINK_PATTERN="^\[.*\].*releases/tag/.*"
+## [v1.2.0]: https://github.com/nasa/harmony-gdal-adapter/releases/tags/1.2.0
+LINK_PATTERN="^\[.*\]:.*https://github.com/nasa"
 
 # Read the file and extract text between the first two occurrences of the
 # VERSION_PATTERN
 result=$(awk "/$VERSION_PATTERN/{c++; if(c==2) exit;} c==1" "$CHANGELOG_FILE")
 
+# Get all commit messages since the last release (marked with a git tag). If
+# there are no tags, get the full commit history of the repository.
+if [[ $(git tag) ]]
+then
+	# There are git tags, so get the most recent one
+	GIT_REF=$(git describe --tags --abbrev=0)
+else
+	# There are not git tags, so get the initial commit of the repository
+	GIT_REF=$(git rev-list --max-parents=0 HEAD)
+fi
+
+# Retrieve the title line of all commit messages since $GIT_REF, filtering out
+# those from the pre-commit-ci[bot] author and any containing the string
+# "nasa/pre-commit-ci-update-config", which may result from merge commits.
+GIT_COMMIT_MESSAGES=$(git log --oneline --format="%s" --perl-regexp --author='^(?!pre-commit-ci\[bot\]).*$' --grep="nasa\/pre-commit-ci-update-config" --invert-grep ${GIT_REF}..HEAD)
+
+# Append git commit messages to the release notes:
+if [[ ${GIT_COMMIT_MESSAGES} ]]
+then
+	result+="\n\n## Commits\n\n${GIT_COMMIT_MESSAGES}"
+fi
+
 # Print the result
-echo "$result" |  grep -v "$VERSION_PATTERN" | grep -v "$LINK_PATTERN"
+echo -e "$result" |  grep -v "$VERSION_PATTERN" | grep -v "$LINK_PATTERN"


### PR DESCRIPTION
## Description

This PR updates the generation of release notes to include the commit history for the release. This is in response to NSIDC wanting an easier way to map between releases and the work included in them.

## Jira Issue ID

TRT-315 (and other NSIDC verification related tickets)

## Local Test Steps

* Pull this branch.
* Run `bin/extract-release-notes.sh` to ensure the most recent release notes are extracted.
* To see expected release notes, see [HGA example](https://github.com/nasa/harmony-gdal-adapter/releases/tag/3.0.2).

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* ~~`docker/service_version.txt` updated if publishing a release.~~ (Only a CI/CD change)
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~